### PR TITLE
Add system packages to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 FROM python:3.12-slim
 WORKDIR /app
 COPY requirements.txt ./
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        pkg-config \
+        default-libmysqlclient-dev \
+    && rm -rf /var/lib/apt/lists/*
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 ENV FLASK_APP=app/app.py


### PR DESCRIPTION
## Summary
- install build-essential, pkg-config and default-libmysqlclient-dev in Dockerfile

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `docker build -t datenlapp .` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686fd2f6240883269f20bd1862734e3d