### PR TITLE
Update README with system package requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ docker compose up --build
 
 Die Weboberfläche ist danach unter `http://localhost:5000` erreichbar.
 
+## Benötigte Pakete
+
+Zum Kompilieren von `mysqlclient` werden einige Systempakete benötigt:
+
+* libmysqlclient-dev (oder libmariadb-dev)
+* build-essential
+
+Diese Pakete installiert das Dockerfile automatisch, bei einer lokalen Installation müssen sie zuvor manuell installiert werden.
+
 ## Manuelles Starten
 
 Alternativ können Sie die Anwendung lokal starten (Python 3.12 vorausgesetzt):


### PR DESCRIPTION
## Summary
- list required system packages for compiling `mysqlclient`
- note that these packages are installed automatically by the Dockerfile

## Testing
- `pytest --maxfail=1 -q`

------
https://chatgpt.com/codex/tasks/task_e_686fd396999c832692207406cd4a801f