### PR TITLE
Add Flask-based privacy request app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+ENV FLASK_APP=app/app.py
+CMD ["flask", "run", "--host=0.0.0.0"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
-# Datenl-schung
+# Incogni Ähnliche Anwendung
+
+Dieses Projekt stellt eine einfache Webanwendung bereit, mit der Nutzer die Löschung ihrer Daten bei Brokern beantragen können. Die Anwendung basiert auf Flask und MySQL und kann per Docker betrieben werden (z. B. auf einem Raspberry Pi).
+
+## Funktionen
+
+* Registrierung mit Benutzername, E‑Mail und Telefonnummer
+* Verschlüsselte Speicherung von E‑Mail und Telefonnummer in MySQL
+* Login und Rollenverwaltung (Kunde und Admin)
+* Admin‑Panel zur Benutzerübersicht
+* Versenden von Löschungsanfragen per E‑Mail an Broker
+
+## Starten mit Docker
+
+1. Passen Sie in `docker-compose.yml` die Umgebungsvariablen für MySQL und Gmail an.
+2. Führen Sie anschließend aus:
+
+```bash
+docker compose up --build
+```
+
+Die Weboberfläche ist danach unter `http://localhost:5000` erreichbar.
+
+## Manuelles Starten
+
+Alternativ können Sie die Anwendung lokal starten (Python 3.12 vorausgesetzt):
+
+```bash
+pip install -r requirements.txt
+export DATABASE_URL="mysql://user:password@localhost/app"
+export GMAIL_USER="you@example.com"
+export GMAIL_PASS="yourpass"
+export ENCRYPTION_KEY="$(python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())')"
+export SECRET_KEY="changeme"
+python app/app.py
+```
+
+## Hinweise
+
+Damit der Versand von E‑Mails über Gmail funktioniert, muss für das verwendete Konto ggf. ein App‑Passwort eingerichtet werden.

--- a/app/app.py
+++ b/app/app.py
@@ -1,0 +1,146 @@
+from flask import Flask, render_template, redirect, url_for, flash, request
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import LoginManager, login_user, login_required, logout_user, current_user, UserMixin
+from flask_wtf import FlaskForm
+from wtforms import StringField, PasswordField, SubmitField
+from wtforms.validators import DataRequired, Email, Length
+from werkzeug.security import generate_password_hash, check_password_hash
+from cryptography.fernet import Fernet
+from flask_mail import Mail, Message
+import os
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'devsecret')
+app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL', 'mysql://user:password@db/app')
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+app.config['MAIL_SERVER'] = 'smtp.gmail.com'
+app.config['MAIL_PORT'] = 587
+app.config['MAIL_USE_TLS'] = True
+app.config['MAIL_USERNAME'] = os.environ.get('GMAIL_USER')
+app.config['MAIL_PASSWORD'] = os.environ.get('GMAIL_PASS')
+
+mail = Mail(app)
+db = SQLAlchemy(app)
+login_manager = LoginManager(app)
+login_manager.login_view = 'login'
+
+ENCRYPTION_KEY = os.environ.get('ENCRYPTION_KEY', Fernet.generate_key())
+fernet = Fernet(ENCRYPTION_KEY)
+
+class User(UserMixin, db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    email_enc = db.Column(db.LargeBinary, nullable=False)
+    phone_enc = db.Column(db.LargeBinary, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+    role = db.Column(db.String(20), default='Kunde')
+
+    @property
+    def email(self):
+        return fernet.decrypt(self.email_enc).decode()
+
+    @property
+    def phone(self):
+        return fernet.decrypt(self.phone_enc).decode()
+
+@login_manager.user_loader
+def load_user(user_id):
+    return User.query.get(int(user_id))
+
+class RegistrationForm(FlaskForm):
+    username = StringField('Benutzername', validators=[DataRequired(), Length(min=3)])
+    email = StringField('E-Mail', validators=[DataRequired(), Email()])
+    phone = StringField('Telefon', validators=[DataRequired(), Length(min=3)])
+    password = PasswordField('Passwort', validators=[DataRequired(), Length(min=6)])
+    submit = SubmitField('Registrieren')
+
+class LoginForm(FlaskForm):
+    username = StringField('Benutzername', validators=[DataRequired()])
+    password = PasswordField('Passwort', validators=[DataRequired()])
+    submit = SubmitField('Anmelden')
+
+@app.route('/')
+def index():
+    return render_template('index.html')
+
+@app.route('/register', methods=['GET', 'POST'])
+def register():
+    form = RegistrationForm()
+    if form.validate_on_submit():
+        hashed = generate_password_hash(form.password.data)
+        user = User(username=form.username.data,
+                    email_enc=fernet.encrypt(form.email.data.encode()),
+                    phone_enc=fernet.encrypt(form.phone.data.encode()),
+                    password_hash=hashed)
+        db.session.add(user)
+        db.session.commit()
+        flash('Registrierung erfolgreich. Bitte anmelden.')
+        return redirect(url_for('login'))
+    return render_template('register.html', form=form)
+
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    form = LoginForm()
+    if form.validate_on_submit():
+        user = User.query.filter_by(username=form.username.data).first()
+        if user and check_password_hash(user.password_hash, form.password.data):
+            login_user(user)
+            return redirect(url_for('dashboard'))
+        flash('Ungültige Anmeldedaten')
+    return render_template('login.html', form=form)
+
+@app.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    return redirect(url_for('index'))
+
+@app.route('/dashboard')
+@login_required
+def dashboard():
+    return render_template('dashboard.html')
+
+@app.route('/admin')
+@login_required
+def admin_panel():
+    if current_user.role != 'admin':
+        flash('Zugriff verweigert')
+        return redirect(url_for('dashboard'))
+    users = User.query.all()
+    return render_template('admin.html', users=users)
+
+BROKER_EMAILS = [
+    'broker1@example.com',
+    'broker2@example.com',
+]
+
+@app.route('/request_deletion')
+@login_required
+def request_deletion():
+    for broker in BROKER_EMAILS:
+        msg = Message('Löschungsanfrage',
+                      sender=app.config['MAIL_USERNAME'],
+                      recipients=[broker])
+        msg.body = f"Bitte löschen Sie alle Daten zu {current_user.username}."
+        mail.send(msg)
+    flash('Löschungsanfragen wurden versendet.')
+    return redirect(url_for('dashboard'))
+
+def _ensure_db_ready(retries: int = 10, delay: int = 2) -> None:
+    """Wait for the database connection before creating tables."""
+    from sqlalchemy.exc import OperationalError
+    import time
+
+    for _ in range(retries):
+        try:
+            db.engine.connect()
+            return
+        except OperationalError:
+            time.sleep(delay)
+    raise RuntimeError("Datenbankverbindung konnte nicht hergestellt werden")
+
+
+if __name__ == '__main__':
+    _ensure_db_ready()
+    db.create_all()
+    app.run(host='0.0.0.0', port=5000)

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -1,0 +1,13 @@
+{% extends 'layout.html' %}
+{% block title %}Admin{% endblock %}
+{% block content %}
+<h2>Admin Panel</h2>
+<table class="table">
+  <thead><tr><th>ID</th><th>Benutzername</th><th>Rolle</th></tr></thead>
+  <tbody>
+  {% for u in users %}
+    <tr><td>{{ u.id }}</td><td>{{ u.username }}</td><td>{{ u.role }}</td></tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,0 +1,8 @@
+{% extends 'layout.html' %}
+{% block title %}Dashboard{% endblock %}
+{% block content %}
+<h2>Hallo {{ current_user.username }}</h2>
+<p>Email: {{ current_user.email }}</p>
+<p>Telefon: {{ current_user.phone }}</p>
+<a href="{{ url_for('request_deletion') }}" class="btn btn-danger">Datenlöschung bei Brokern beantragen</a>
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,11 @@
+{% extends 'layout.html' %}
+{% block title %}Startseite{% endblock %}
+{% block content %}
+<div class="text-center">
+  <h1>Willkommen</h1>
+  <p>Diese Anwendung ermöglicht Ihnen die einfache Beantragung der Datenlöschung bei Brokern.</p>
+  {% if not current_user.is_authenticated %}
+  <a href="{{ url_for('register') }}" class="btn btn-primary">Jetzt registrieren</a>
+  {% endif %}
+</div>
+{% endblock %}

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <title>{% block title %}Incogni Clone{% endblock %}</title>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light mb-4">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="{{ url_for('index') }}">Datenschutz</a>
+    <div class="collapse navbar-collapse">
+      <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
+        {% if current_user.is_authenticated %}
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('dashboard') }}">Dashboard</a></li>
+          {% if current_user.role == 'admin' %}
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('admin_panel') }}">Admin</a></li>
+          {% endif %}
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('logout') }}">Logout</a></li>
+        {% else %}
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('login') }}">Login</a></li>
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('register') }}">Registrieren</a></li>
+        {% endif %}
+      </ul>
+    </div>
+  </div>
+</nav>
+<div class="container">
+{% with messages = get_flashed_messages() %}
+  {% if messages %}
+    {% for msg in messages %}
+      <div class="alert alert-info">{{ msg }}</div>
+    {% endfor %}
+  {% endif %}
+{% endwith %}
+{% block content %}{% endblock %}
+</div>
+</body>
+</html>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,0 +1,11 @@
+{% extends 'layout.html' %}
+{% block title %}Anmelden{% endblock %}
+{% block content %}
+<h2>Anmeldung</h2>
+<form method="post">
+  {{ form.hidden_tag() }}
+  <div class="mb-3">{{ form.username.label }} {{ form.username(class_='form-control') }}</div>
+  <div class="mb-3">{{ form.password.label }} {{ form.password(class_='form-control') }}</div>
+  {{ form.submit(class_='btn btn-primary') }}
+</form>
+{% endblock %}

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -1,0 +1,13 @@
+{% extends 'layout.html' %}
+{% block title %}Registrieren{% endblock %}
+{% block content %}
+<h2>Registrierung</h2>
+<form method="post">
+  {{ form.hidden_tag() }}
+  <div class="mb-3">{{ form.username.label }} {{ form.username(class_='form-control') }}</div>
+  <div class="mb-3">{{ form.email.label }} {{ form.email(class_='form-control') }}</div>
+  <div class="mb-3">{{ form.phone.label }} {{ form.phone(class_='form-control') }}</div>
+  <div class="mb-3">{{ form.password.label }} {{ form.password(class_='form-control') }}</div>
+  {{ form.submit(class_='btn btn-primary') }}
+</form>
+{% endblock %}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.9'
+services:
+  db:
+    image: mysql:8
+    environment:
+      MYSQL_DATABASE: app
+      MYSQL_ROOT_PASSWORD: rootpass
+      MYSQL_USER: user
+      MYSQL_PASSWORD: password
+    volumes:
+      - db_data:/var/lib/mysql
+  web:
+    build: .
+    ports:
+      - "5000:5000"
+    environment:
+      DATABASE_URL: mysql://user:password@db/app
+      GMAIL_USER: yourgmail@example.com
+      GMAIL_PASS: yourgmailpassword
+      ENCRYPTION_KEY: yourverysecretkeybase64==
+      SECRET_KEY: changeme
+    depends_on:
+      - db
+volumes:
+  db_data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+Flask
+flask_sqlalchemy
+flask_wtf
+flask_login
+flask_mail
+email-validator
+cryptography
+mysqlclient


### PR DESCRIPTION
## Summary
- add a Flask application with login and registration
- use MySQL for storage and encrypt sensitive data
- include simple admin panel and email deletion request
- provide Docker and docker-compose setup
- document usage in README
- add DB wait routine so container startup succeeds

## Testing
- `python -m py_compile app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_686fd09081f083268e42a17d02e1a361