### PR TITLE
Add initialization hook for database

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ export GMAIL_PASS="yourpass"
 export ENCRYPTION_KEY="$(python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())')"
 export SECRET_KEY="changeme"
 python app/app.py
+# oder alternativ
+flask --app app/app.py run
 ```
 
 ## Hinweise

--- a/app/app.py
+++ b/app/app.py
@@ -23,10 +23,6 @@ mail = Mail(app)
 db = SQLAlchemy(app)
 
 
-# Ensure tables are created when the application starts
-with app.app_context():
-    db.create_all()
-
 
 login_manager = LoginManager(app)
 login_manager.login_view = 'login'
@@ -148,9 +144,14 @@ def _ensure_db_ready(retries: int = 10, delay: int = 2) -> None:
     raise RuntimeError("Datenbankverbindung konnte nicht hergestellt werden")
 
 
-if __name__ == '__main__':
+@app.before_first_request
+def initialize() -> None:
+    """Ensure database is ready and create tables."""
     _ensure_db_ready()
-    db.create_all()
+    with app.app_context():
+        db.create_all()
+
 
 if __name__ == '__main__':
+    initialize()
     app.run(host='0.0.0.0', port=5000)


### PR DESCRIPTION
## Summary
- add an `initialize` function to create tables on first request
- call `initialize` in `__main__` section
- mention `flask --app app/app.py run` in README

## Testing
- `python -m py_compile app/app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fdeeebc888326bb3cfc6bc06ce0a5